### PR TITLE
dropdown: fix when the outermost layer of a dropdown component is an SVG, clicking the SVG element will cause an error on the console

### DIFF
--- a/packages/element3/packages/dropdown/src/dropdown.vue
+++ b/packages/element3/packages/dropdown/src/dropdown.vue
@@ -271,11 +271,12 @@ export default {
         '.el-dropdown-selfdefine'
       )
       if (selfDefine) {
+        const originClassName = selfDefine.getAttribute('class')
         // 自定义
         if (val) {
-          selfDefine.className += ' focusing'
+          selfDefine.setAttribute('class', `${originClassName} focusing`)
         } else {
-          selfDefine.className = selfDefine.className.replace('focusing', '')
+          selfDefine.setAttribute('class', originClassName.replace('focusing', ''))
         }
       }
     })


### PR DESCRIPTION

【Reproduction code】

```vue
<el-dropdown @command="onDropdownClick">
  <svg
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    aria-hidden="true"
    role="img"
    class="iconify iconify--carbon"
    :width="25"
    :height="25"
    preserveAspectRatio="xMidYMid meet"
    viewBox="0 0 32 32"
  >
    <path
      fill="currentColor"
      d="M24 9.4L22.6 8L16 14.6L9.4 8L8 9.4l6.6 6.6L8 22.6L9.4 24l6.6-6.6l6.6 6.6l1.4-1.4l-6.6-6.6L24 9.4z"
    ></path>
  </svg>
  <el-dropdown-menu>
    <el-dropdown-item command="edit">编辑</el-dropdown-item>
    <el-dropdown-item command="delete">删除</el-dropdown-item>
  </el-dropdown-menu>
</el-dropdown>
```

【Error】
element3-ui.esm-bundler.js?c010:31394 
        
Uncaught (in promise) TypeError: Cannot set property className of #<SVGElement> which has only a getter
    at eval (element3-ui.esm-bundler.js?c010:31394:1)
    at callWithErrorHandling (runtime-core.esm-bundler.js?5c40:155:1)
    at callWithAsyncErrorHandling (runtime-core.esm-bundler.js?5c40:164:1)
    at Array.job (runtime-core.esm-bundler.js?5c40:1779:1)
    at flushPreFlushCbs (runtime-core.esm-bundler.js?5c40:328:1)
    at flushJobs (runtime-core.esm-bundler.js?5c40:369:1)
